### PR TITLE
Solution: Phase 1

### DIFF
--- a/src/main/java/com/onfleet/demo/homework/collection/Tasklist.java
+++ b/src/main/java/com/onfleet/demo/homework/collection/Tasklist.java
@@ -17,9 +17,6 @@ import java.util.Collection;
  */
 @SuppressWarnings("WeakerAccess")
 public final class Tasklist implements Comparable<Tasklist> {
-  // -- algorithm configuration -- //
-  public final static double TASK_COUNT_WEIGHT = 0.2;
-
   // -- internals -- //
   /**
    * Assigned {@link Driver} for this tasklist.
@@ -135,8 +132,7 @@ public final class Tasklist implements Comparable<Tasklist> {
    * tasks for this {@link Driver}.
    */
   private void recalculateLoadEstimate() {
-    final double taskCountAsDouble = (double)this.taskCount;
-    this.loadEstimate += ((this.knownDistance / taskCountAsDouble) * (taskCountAsDouble * TASK_COUNT_WEIGHT));
+    this.loadEstimate = this.knownDistance;
   }
 
   // -- interface compliance: Comparable<Tasklist> -- //

--- a/src/main/java/com/onfleet/demo/homework/manager/BlindTaskManager.java
+++ b/src/main/java/com/onfleet/demo/homework/manager/BlindTaskManager.java
@@ -8,7 +8,6 @@ import com.onfleet.demo.homework.struct.Task;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -47,7 +46,7 @@ public final class BlindTaskManager extends BaseTaskManager implements TaskAssig
    * @param candidateTask Cost difference for list with task assigned.
    * @return "Cost" estimate for this tasklist, given the additional candidate {@link Task}.
    */
-  private double costForTasklist(final Collection<Task> tasklist, final Task candidateTask) {
+  private double costForTasklist(final Iterable<Task> tasklist, final Task candidateTask) {
     // calculate the summed distance of all tasks...
     double summedDistance = 0.0;
     Task lastTaskSeen = null;
@@ -56,11 +55,8 @@ public final class BlindTaskManager extends BaseTaskManager implements TaskAssig
       lastTaskSeen = taskItem;
     }
 
-    double count = (double)tasklist.size();
-
-    // factor in count of tasks and total distance, with this candidate task considered
-    return (count + 1.0) * (Tasklist.TASK_COUNT_WEIGHT * (summedDistance
-                             + Tasklist.calculateDistanceForPoints(lastTaskSeen, candidateTask)));
+    // simple distance, for now, added to the end of the list
+    return summedDistance + Tasklist.calculateDistanceForPoints(lastTaskSeen, candidateTask);
   }
 
   // -- public API -- //

--- a/src/main/java/com/onfleet/demo/homework/manager/TaskManager.java
+++ b/src/main/java/com/onfleet/demo/homework/manager/TaskManager.java
@@ -31,7 +31,7 @@ public final class TaskManager extends BaseTaskManager implements TaskAssigner {
   /**
    * Build a new task manager, given a set of drivers we will be distributing tasks over.
    */
-  TaskManager(final Collection<Driver> drivers) {
+  private TaskManager(final Collection<Driver> drivers) {
     // setup initial driver tasklists
     final Map<Driver, Tasklist> tasklistMap = new HashMap<>(drivers.size());
 

--- a/src/main/java/com/onfleet/demo/homework/util/ObjectGenerator.java
+++ b/src/main/java/com/onfleet/demo/homework/util/ObjectGenerator.java
@@ -79,7 +79,8 @@ final public class ObjectGenerator {
     final double longitudeHiMark;
 
     /**
-     * Seal watermarks in a structure to contain them.
+     * Seal watermarks in a structure to contain them, and pre-compute
+     * a higher-resolution copy via multiplication.
      *
      * @param latitudeLowMark Lowest latitude encountered.
      * @param latitudeHiMark Highest latitude encountered.
@@ -90,10 +91,10 @@ final public class ObjectGenerator {
                       final double latitudeHiMark,
                       final double longitudeLowMark,
                       final double longitudeHiMark) {
-      this.latitudeLowMark = latitudeLowMark;
-      this.latitudeHiMark = latitudeHiMark;
-      this.longitudeLowMark = longitudeLowMark;
-      this.longitudeHiMark = longitudeHiMark;
+      this.latitudeLowMark = latitudeLowMark * Watermarks.precisionMultiple;
+      this.latitudeHiMark = latitudeHiMark * Watermarks.precisionMultiple;
+      this.longitudeLowMark = longitudeLowMark * Watermarks.precisionMultiple;
+      this.longitudeHiMark = longitudeHiMark * Watermarks.precisionMultiple;
     }
 
     /**
@@ -130,15 +131,15 @@ final public class ObjectGenerator {
    *
    * @return Random Location.
    */
+  @SuppressWarnings("MagicNumber")
   static @NotNull Geopoint randomLocationWithinBounds() {
     // quick and dirty algorithm to generate roughly within the points
     final Random randomGenerator = RandomNumberUtil.getRandomGenerator();
 
-    // @TODO: cache these
-    final double morePreciseLowLatitude = geopointWatermarks.getLatitudeLowMark() * Watermarks.precisionMultiple;
-    final double morePreciseLowLongitude = geopointWatermarks.getLongitudeLowMark() * Watermarks.precisionMultiple;
-    final double morePreciseHiLatitude = geopointWatermarks.getLatitudeHiMark() * Watermarks.precisionMultiple;
-    final double morePreciseHiLongitude = geopointWatermarks.getLongitudeHiMark() * Watermarks.precisionMultiple;
+    final double morePreciseLowLatitude = geopointWatermarks.getLatitudeLowMark();
+    final double morePreciseLowLongitude = geopointWatermarks.getLongitudeLowMark();
+    final double morePreciseHiLatitude = geopointWatermarks.getLatitudeHiMark();
+    final double morePreciseHiLongitude = geopointWatermarks.getLongitudeHiMark();
 
     double xValue = Math.abs(morePreciseLowLatitude) + randomGenerator.nextInt(Math.abs((int)morePreciseHiLatitude / 100));
     double yValue = Math.abs(morePreciseLowLongitude) + randomGenerator.nextInt(Math.abs((int)morePreciseHiLongitude / 100));

--- a/src/test/java/com/onfleet/demo/homework/cli/MainTest.java
+++ b/src/test/java/com/onfleet/demo/homework/cli/MainTest.java
@@ -12,7 +12,8 @@ import java.io.IOException;
  */
 public final class MainTest {
   @Test
-  public void testConstructLogger() {
+  public void testConstructors() {
+    new Main();
     new AppLogger();
     AppLogger._enableLogging();
     AppLogger._enableLogging(true);

--- a/src/test/java/com/onfleet/demo/homework/manager/BlindTaskManagerTest.java
+++ b/src/test/java/com/onfleet/demo/homework/manager/BlindTaskManagerTest.java
@@ -1,0 +1,49 @@
+package com.onfleet.demo.homework.manager;
+
+
+import com.onfleet.demo.homework.struct.Driver;
+import com.onfleet.demo.homework.struct.Task;
+import com.onfleet.demo.homework.util.ObjectGenerator;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * Applies {@link TaskAssignerTest}-based logic to {@link BlindTaskManager}.
+ */
+@SuppressWarnings("unused")
+public final class BlindTaskManagerTest extends TaskAssignerTest {
+  @Test
+  public void testBlindTaskManagerConstructor() {
+    final TaskManager manager = TaskManager.setupWithDataset(this.getSampleDataset());
+    final BlindTaskManager blind = new BlindTaskManager(manager);
+  }
+
+  @Test
+  public void testBlindTaskManagerAssignTasks() {
+    final TaskManager manager = TaskManager.setupWithDataset(this.getSampleDataset());
+    final BlindTaskManager blind = new BlindTaskManager(manager);
+    final Task task = ObjectGenerator.generateTask();
+    final Driver lowestCost = blind.resolveLowestCostAssignment(task);
+    Assert.assertNotNull("lowest cost driver assignment from blind manager should not be null", lowestCost);
+    blind.assignToDriver(lowestCost, task);
+  }
+
+  @Test
+  public void testResolutionConsistency() {
+    this.testResolutionForConsistency(new BlindTaskManager(
+        TaskManager.setupWithDataset(this.getSampleDataset())));
+  }
+
+  @Test
+  public void testAssignTaskToPreviouslyUnknownDriver() {
+    this.testAssignTaskToPreviouslyUnknownDriver(new BlindTaskManager(
+        TaskManager.setupWithDataset(this.getSampleDataset())));
+  }
+
+  @Test
+  public void testAssignMultipleTasks() {
+    this.testAssignMultipleTasks(new BlindTaskManager(
+        TaskManager.setupWithDataset(this.getSampleDataset())));
+  }
+}

--- a/src/test/java/com/onfleet/demo/homework/manager/TaskAssignerTest.java
+++ b/src/test/java/com/onfleet/demo/homework/manager/TaskAssignerTest.java
@@ -1,0 +1,91 @@
+package com.onfleet.demo.homework.manager;
+
+
+import com.onfleet.demo.homework.FixturedTest;
+import com.onfleet.demo.homework.TaskAssigner;
+import com.onfleet.demo.homework.collection.Tasklist;
+import com.onfleet.demo.homework.struct.Driver;
+import com.onfleet.demo.homework.struct.Task;
+import com.onfleet.demo.homework.util.ObjectGenerator;
+import org.junit.Assert;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+
+/**
+ * Supplies test methods for classes that comply with {@link com.onfleet.demo.homework.TaskAssigner}.
+ */
+abstract class TaskAssignerTest extends FixturedTest {
+  /**
+   * Test that resolving the lowest-cost-assignment happens in an entirely consistent
+   * way - i.e. that the same result is returned, given identical state, for the same
+   * candidate task.
+   *
+   * @param assigner Assigning manager implementation.
+   */
+  void testResolutionForConsistency(final TaskAssigner assigner) {
+    final Task generatedTask = ObjectGenerator.generateTask();
+    final Driver lowestCost1 = assigner.resolveLowestCostAssignment(generatedTask);
+    final Driver lowestCost2 = assigner.resolveLowestCostAssignment(generatedTask);
+
+    Assert.assertEquals("lowest-cost-assignment algorithm for implementation '"
+                            + assigner.getClass().getSimpleName()
+                            + "' needs to be consistent", lowestCost1, lowestCost2);
+  }
+
+  /**
+   * Test assigning an arbitrary task to a specific {@link Driver}.
+   *
+   * @param assigner Assigning manager implementation.
+   */
+  void testAssignTaskToPreviouslyUnknownDriver(final TaskAssigner assigner) {
+    final Driver generatedDriver = ObjectGenerator.generateDriver();
+    final Task generatedTask = ObjectGenerator.generateTask();
+    assigner.assignToDriver(generatedDriver, generatedTask);
+    final Tasklist tasklistForDriver = assigner.tasklistForDriver(generatedDriver);
+
+    Assert.assertNotNull("tasklist for known driver should not return null",
+                         tasklistForDriver);
+    Assert.assertTrue("tasklist for known driver should contain task just assigned to it",
+                      tasklistForDriver.getAssignedTasks().contains(generatedTask));
+
+    final int assignedTasksBefore = tasklistForDriver.getTaskCount();
+    final double knownDistanceBefore = tasklistForDriver.getKnownDistance();
+    final double loadEstimateBefore = tasklistForDriver.getLoadEstimate();
+
+    final Task generatedTask2 = ObjectGenerator.generateTask();
+    assigner.assignToDriver(generatedDriver, generatedTask2);
+
+    final Tasklist tasklistForDriver2 = assigner.tasklistForDriver(generatedDriver);
+
+    Assert.assertNotNull("tasklist for known driver should not return null after second op",
+                         tasklistForDriver2);
+    Assert.assertTrue("tasklist for known driver should contain second task just assigned to it",
+                      tasklistForDriver2.getAssignedTasks().contains(generatedTask2));
+    Assert.assertTrue("known distance should change when a new task is added",
+                      !tasklistForDriver2.getKnownDistance().equals(knownDistanceBefore));
+    Assert.assertTrue("task count should change when a new task is added",
+                      !tasklistForDriver2.getTaskCount().equals(assignedTasksBefore));
+    Assert.assertTrue("load estimate should change when a new task is added",
+                      !tasklistForDriver2.getLoadEstimate().equals(loadEstimateBefore));
+  }
+
+  /**
+   * Test assigning multiple tasks at once.
+   *
+   * @param assigner Assigning manager implementation.
+   */
+  void testAssignMultipleTasks(final TaskAssigner assigner) {
+    final Driver generatedDriver = ObjectGenerator.generateDriver();
+    final Task generatedTask = ObjectGenerator.generateTask();
+    final Task generatedTask2 = ObjectGenerator.generateTask();
+    final Task generatedTask3 = ObjectGenerator.generateTask();
+
+    final Collection<Task> tasklist = new ArrayList<>(3);
+    tasklist.add(generatedTask);
+    tasklist.add(generatedTask2);
+    tasklist.add(generatedTask3);
+    assigner.assignToDriver(generatedDriver, tasklist);
+  }
+}

--- a/src/test/java/com/onfleet/demo/homework/manager/TaskManagerTest.java
+++ b/src/test/java/com/onfleet/demo/homework/manager/TaskManagerTest.java
@@ -1,16 +1,8 @@
 package com.onfleet.demo.homework.manager;
 
 
-import com.onfleet.demo.homework.FixturedTest;
 import com.onfleet.demo.homework.TaskAssigner;
-import com.onfleet.demo.homework.struct.Driver;
-import com.onfleet.demo.homework.struct.Task;
-import com.onfleet.demo.homework.util.ObjectGenerator;
-import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -19,12 +11,7 @@ import static org.junit.Assert.assertNotNull;
  * Test the {@link TaskManager} and {@link BlindTaskManager} object.
  */
 @SuppressWarnings("unused")
-public final class TaskManagerTest extends FixturedTest {
-  @Test
-  public void testConstruct() {
-    new TaskManager(this.getSampleDataset().getGeneratedDrivers());
-  }
-
+public final class TaskManagerTest extends TaskAssignerTest {
   @Test
   public void testConstructViaPublicAPI() {
     final TaskAssigner manager = TaskManager.setupWithDataset(this.getSampleDataset());
@@ -32,43 +19,17 @@ public final class TaskManagerTest extends FixturedTest {
   }
 
   @Test
+  public void testResolutionConsistency() {
+    this.testResolutionForConsistency(TaskManager.setupWithDataset(this.getSampleDataset()));
+  }
+
+  @Test
   public void testAssignTaskToPreviouslyUnknownDriver() {
-    final TaskAssigner manager = new TaskManager(this.getSampleDataset().getGeneratedDrivers());
-    final Driver generatedDriver = ObjectGenerator.generateDriver();
-    final Task generatedTask = ObjectGenerator.generateTask();
-    manager.assignToDriver(generatedDriver, generatedTask);
+    this.testAssignTaskToPreviouslyUnknownDriver(TaskManager.setupWithDataset(this.getSampleDataset()));
   }
 
   @Test
   public void testAssignMultipleTasks() {
-    final TaskAssigner manager = new TaskManager(this.getSampleDataset().getGeneratedDrivers());
-    final Driver generatedDriver = ObjectGenerator.generateDriver();
-    final Task generatedTask = ObjectGenerator.generateTask();
-    final Task generatedTask2 = ObjectGenerator.generateTask();
-    final Task generatedTask3 = ObjectGenerator.generateTask();
-
-    final Collection<Task> tasklist = new ArrayList<>(3);
-    tasklist.add(generatedTask);
-    tasklist.add(generatedTask2);
-    tasklist.add(generatedTask3);
-    manager.assignToDriver(generatedDriver, tasklist);
-  }
-
-  @Test
-  public void testBlindTaskManagerConstructor() {
-    final TaskManager manager = TaskManager.setupWithDataset(this.getSampleDataset());
-    final BlindTaskManager blind = new BlindTaskManager(manager);
-  }
-
-  @Test
-  public void testBlindTaskManagerAssignTasks() {
-    final TaskManager manager = TaskManager.setupWithDataset(this.getSampleDataset());
-    final BlindTaskManager blind = new BlindTaskManager(manager);
-    final Task task = ObjectGenerator.generateTask();
-    final Driver lowestCost = blind.resolveLowestCostAssignment(task);
-
-    Assert.assertNotNull("lowest cost driver assignment from blind manager should not be null", lowestCost);
-
-    blind.assignToDriver(lowestCost, task);
+    this.testAssignMultipleTasks(TaskManager.setupWithDataset(this.getSampleDataset()));
   }
 }

--- a/src/test/java/com/onfleet/demo/homework/struct/StructureTest.java
+++ b/src/test/java/com/onfleet/demo/homework/struct/StructureTest.java
@@ -5,6 +5,7 @@ import com.onfleet.demo.homework.FixturedTest;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
@@ -26,6 +27,37 @@ public final class StructureTest extends FixturedTest {
   public void testDriverObjectFromJSON() throws IOException {
     final String jsonSample = "{\"uuid\": \"ed01d72e-02f8-4ba3-be22-d00fe19b3632\", \"name\": \"Bill Withers\"}";
     this.objectMapper().readerFor(Driver.class).readValue(jsonSample);
+  }
+
+  @Test
+  public void testDriverObjectToString() throws IOException {
+    final Driver subject = this.getSampleDataset().getGeneratedDrivers().iterator().next();
+    assertEquals("driver.toString() should return a name when it has one",
+                 subject.getName(),
+                 subject.toString());
+
+    final Driver subject2 = Driver.factory(null);
+    assertEquals("driver.toString() should return a UUID when it has no name",
+                 subject2.getUuid(),
+                 subject2.toString());
+  }
+
+  @Test
+  public void testDriverObjectComparison() throws IOException {
+    final Driver subject = this.getSampleDataset().getGeneratedDrivers().iterator().next();
+    final Driver sameSubject = this.getSampleDataset().getGeneratedDrivers().iterator().next();
+
+    Iterator<Driver> driverIterator = this.getSampleDataset().getGeneratedDrivers().iterator();
+    driverIterator.next();  // skip first
+    final Driver differentSubject = driverIterator.next();
+
+    assertEquals("identical drivers should equal each other",
+                 subject,
+                 sameSubject);
+
+    assertNotEquals("different drivers should equal each other",
+                    subject,
+                    differentSubject);
   }
 
   @Test
@@ -95,6 +127,11 @@ public final class StructureTest extends FixturedTest {
     assertTrue("geopoint.toString should start with 'Point'", geopoint1.toString().startsWith("Point"));
     assertNotEquals("geopoint.hashCode should vary between non-identical points", geopoint1.hashCode(), geopoint3.hashCode());
     assertEquals("geopoint.hashCode should not vary between identical points", geopoint1.hashCode(), geopoint2.hashCode());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testGeopointNullCheck() {
+    @SuppressWarnings("ConstantConditions") final Geopoint geopoint1 = new Geopoint(null, null);
   }
 
   @Test

--- a/src/test/java/com/onfleet/demo/homework/util/NameHelperTest.java
+++ b/src/test/java/com/onfleet/demo/homework/util/NameHelperTest.java
@@ -13,7 +13,8 @@ import static org.junit.Assert.assertTrue;
 
 
 /**
- * Created by sam on 4/24/17.
+ * Tests {@link NameHelper}, which parses random name data and generates random
+ * names for {@link com.onfleet.demo.homework.struct.Driver} records.
  */
 @SuppressWarnings("unused")
 public class NameHelperTest extends FixturedTest {
@@ -42,5 +43,12 @@ public class NameHelperTest extends FixturedTest {
 
     assertTrue("NameHelper.hasNext should always be true", nameHelper.hasNext());
     assertNotNull("NameHelper.next should return a randomly-generated name", nameHelper.next());
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testConstructNameHelperIteratorRemove() throws IOException {
+    final SampleDataset dataset = this.getSampleDataset();
+    final NameHelper nameHelper = dataset.getNames();
+    nameHelper.remove();
   }
 }

--- a/src/test/java/com/onfleet/demo/homework/util/ObjectGeneratorTest.java
+++ b/src/test/java/com/onfleet/demo/homework/util/ObjectGeneratorTest.java
@@ -18,6 +18,11 @@ import static org.junit.Assert.assertNull;
  */
 public class ObjectGeneratorTest extends FixturedTest {
   @Test
+  public void testEmptyConstructor() {
+    new ObjectGenerator();
+  }
+
+  @Test
   public void testGenerateDriver() {
     final Driver newDriver = ObjectGenerator.generateDriver();
     assertNotNull("generated driver must not be null", newDriver);


### PR DESCRIPTION
Finish out _Phase 1_ of the solution, which involves a naive algorithm to accomplish the on-read side of the problem.

Also, setup abstract tests that work against all `TaskAssigner` implementations (or should!). This allows us to test both `TaskManager` and `BlindTaskManager` for consistency, with a uniform set of tests that take much less code to express.

In summary:
- Add abstract tests for classes adhering `TaskAssigner`
- Add tests to cover additional utility code
- Make the `TaskManager` constructor private, since using it versions the static factory method can be confusing